### PR TITLE
Add the ability to specify architecture.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ convertToWindowsStore({
   makePri: true,
   createConfigParams: ['/a'],
   createPriParams: ['/b'],
+  architecture: 'x64',
   finalSay: function () {
     return new Promise((resolve, reject) => resolve())
   }

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -145,6 +145,7 @@ function convertWithFileCopy (program) {
       result = result.replace(/\${packageDisplayName}/g, program.packageDisplayName || program.packageName)
       result = result.replace(/\${packageDescription}/g, program.packageDescription || program.packageName)
       result = result.replace(/\${packageBackgroundColor}/g, program.packageBackgroundColor || '#464646')
+      result = result.replace(/\${architecture}/g, program.architecture || 'x64')
 
       fs.writeFile(manifest, result, 'utf8', (err) => {
         if (err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,7 @@ const makepri = require('./makepri')
  * @property {string}    assets                  - Path to the visual assets for the appx
  * @property {string}    manifest                - Path to a manifest, if you want to overwrite the default one
  * @property {boolean}   deploy                  - Should the app be deployed after creation?
+ * @property {string}    architecture            - Target architecture for the package (x64, x86, arm, arm64)
  * @property {string}    publisher               - Publisher to use (example: CN=developmentca)
  * @property {string}    windowsKit              - Path to the Windows Kit bin folder
  * @property {string}    devCert                 - Path to the developer certificate to use

--- a/template/appxmanifest.xml
+++ b/template/appxmanifest.xml
@@ -4,7 +4,7 @@
    xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
    xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
   <Identity Name="${identityName}"
-    ProcessorArchitecture="x64"
+    ProcessorArchitecture="${architecture}"
     Publisher="${publisherName}"
     Version="${packageVersion}" />
   <Properties>


### PR DESCRIPTION
This adds the ability to specify the architecture so that packages uploaded to Microsoft Partner Center are accurately reflected.

Note: This change was not comprehensive – other uses of the tool may not supported this flag. This was created to solve a narrow use case.